### PR TITLE
[QUICKFIX] Fixing release workflow to use new goreleaser too

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,8 +16,7 @@ jobs:
         uses: goreleaser/goreleaser-action@v6
         with:
           distribution: goreleaser
-          #To keep same behavior
-          version: '~> v1'
+          version: '~> v2'
           args: release
         env:
           GITHUB_TOKEN: ${{ secrets.CUSTOM_GITHUB_TOKEN }}


### PR DESCRIPTION
Forgot to also use the v2 version.

Fixing it and hopefully it should work when creating a tag ?
